### PR TITLE
Add Hire30A coming soon experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# hire30a
+# Hire30A Coming-Soon Experience
+
+Hire30A is a search-optimized, mobile-ready landing experience for hospitality hiring along Florida's Scenic 30A corridor. The project highlights jobs, resumes, neighborhood insights, and an admin preview that simulates future platform controls.
+
+## Features
+
+- **SEO-first landing page** with structured data, canonical tags, open graph metadata, and a sitemap/robots combo.
+- **Dynamic job board** featuring location, category, and schedule filters that cover Santa Rosa Beach, Destin, Panama City Beach, and surrounding districts.
+- **Resume spotlight grid** showcasing local talent, with submission forms that persist to `localStorage` for instant previews.
+- **Admin portal prototype** to manage brand colors, hero messaging, and community submissions while syncing updates across tabs.
+- **Coming-soon storytelling** including roadmap, micro-market highlights, newsletter capture, and animated hiring pulse ticker.
+
+## Structure
+
+```
+.
+├── index.html            # Public landing page with jobs, resumes, and newsletter capture
+├── admin.html            # Admin preview for branding, content, and submission management
+├── assets
+│   ├── css
+│   │   └── main.css      # Global styling and responsive layout
+│   ├── js
+│   │   ├── main.js       # Landing page interactivity and filter logic
+│   │   └── admin.js      # Admin portal controls and data exports
+│   └── images            # Brand illustrations, logos, and favicons
+├── robots.txt            # Crawl directives pointing to sitemap
+├── sitemap.xml           # Discoverable URLs for search engines
+└── site.webmanifest      # Progressive web app metadata for mobile devices
+```
+
+## Local Preview
+
+Open `index.html` or `admin.html` directly in your browser or serve the directory using any static server (for example, `python -m http.server`). Job and resume submissions are stored in `localStorage`, so data will persist per browser.
+
+## Customization
+
+1. Visit `admin.html` to adjust brand colors, hero copy, and review submissions.
+2. Submit jobs or resumes from the public landing page.
+3. Refresh the public site to view synchronized updates via browser storage events.
+
+## Roadmap Highlights
+
+This coming-soon build is the foundation for deeper functionality such as authenticated employer/candidate accounts, ATS integrations, analytics dashboards, and automated distribution of hospitality opportunities throughout the Emerald Coast.

--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,176 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Hire30A Admin Portal | Customize & Curate</title>
+  <meta name="description" content="Control the Hire30A experience: update branding, refresh content, and review job and resume submissions." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Raleway:wght@300;400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/css/main.css" />
+  <link rel="icon" type="image/svg+xml" href="assets/images/favicon.svg" />
+</head>
+<body class="section-alt">
+  <header class="top-nav">
+    <div class="container">
+      <a class="brand" href="index.html">
+        <img src="assets/images/hire30a-logo.svg" alt="Hire30A logo" width="140" height="36" loading="lazy" />
+      </a>
+      <nav>
+        <ul class="nav-list">
+          <li><a href="index.html#top">Public Site</a></li>
+          <li><a href="#theme">Branding</a></li>
+          <li><a href="#content">Content</a></li>
+          <li><a href="#submissions">Submissions</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="section" aria-labelledby="admin-heading">
+      <div class="container">
+        <div class="section-header">
+          <h1 id="admin-heading">Hire30A Admin Portal</h1>
+          <p>Preview the controls that will power the full Hire30A platform. Adjust colors, update copy, and monitor the 30A hiring pulse in real-time.</p>
+        </div>
+        <div class="feature-grid">
+          <article class="feature-card">
+            <h3>Dynamic Branding</h3>
+            <p>Update coastal colors and typography accents instantly. The public site reflects changes using progressive enhancement.</p>
+          </article>
+          <article class="feature-card">
+            <h3>Content Studio</h3>
+            <p>Craft headline messaging, teaser copy, and spotlight notes to keep the community engaged before launch.</p>
+          </article>
+          <article class="feature-card">
+            <h3>Submission HQ</h3>
+            <p>Review locally submitted jobs and resumes, export data, and curate what appears on the homepage.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="theme" class="section" aria-labelledby="theme-heading">
+      <div class="container">
+        <div class="section-header">
+          <h2 id="theme-heading">Brand Controls</h2>
+          <p>Set a signature palette for Hire30A. Save your choices to see them applied instantly on the public site.</p>
+        </div>
+        <form id="theme-form" class="card">
+          <div class="field">
+            <label for="primary-color">Primary Coastline Hue</label>
+            <input type="color" id="primary-color" name="primaryColor" value="#0096a1" />
+          </div>
+          <div class="field">
+            <label for="secondary-color">Seafoam Accent</label>
+            <input type="color" id="secondary-color" name="secondaryColor" value="#7ed4d4" />
+          </div>
+          <div class="field">
+            <label for="accent-color">Sunset Highlight</label>
+            <input type="color" id="accent-color" name="accentColor" value="#ff7a59" />
+          </div>
+          <button class="button" type="submit">Save Branding</button>
+          <button class="button button-outline" id="reset-theme" type="button">Reset to Default</button>
+          <p class="form-footnote">Brand updates persist locally and cascade to all connected tabs using browser storage events.</p>
+        </form>
+      </div>
+    </section>
+
+    <section id="content" class="section section-alt" aria-labelledby="content-heading">
+      <div class="container">
+        <div class="section-header">
+          <h2 id="content-heading">Content Manager</h2>
+          <p>Shape the launch story. Adjust hero copy and share spotlight messaging while we finalize authentication and full CMS tools.</p>
+        </div>
+        <form id="content-form" class="card">
+          <div class="field">
+            <label for="hero-heading-input">Hero Headline</label>
+            <input id="hero-heading-input" name="heroHeading" />
+          </div>
+          <div class="field">
+            <label for="hero-lead-input">Hero Supporting Copy</label>
+            <textarea id="hero-lead-input" name="heroLead" rows="4"></textarea>
+          </div>
+          <button class="button" type="submit">Update Messaging</button>
+          <button class="button button-outline" id="reset-content" type="button">Use Defaults</button>
+          <p class="form-footnote">Changes sync instantly with the homepage hero for a seamless coming-soon experience.</p>
+        </form>
+      </div>
+    </section>
+
+    <section id="submissions" class="section" aria-labelledby="submissions-heading">
+      <div class="container">
+        <div class="section-header">
+          <h2 id="submissions-heading">Community Submissions</h2>
+          <p>Monitor new opportunities and talent. Export data to share with hiring managers or to preload into ATS integrations.</p>
+        </div>
+        <div class="card">
+          <div class="form-grid">
+            <div>
+              <h3>Jobs Queue</h3>
+              <p class="form-footnote">Filter by location or download as JSON for offline curation.</p>
+              <div class="field">
+                <label for="job-area-filter">Filter by area</label>
+                <select id="job-area-filter">
+                  <option value="">All districts</option>
+                  <option>Santa Rosa Beach</option>
+                  <option>Seaside</option>
+                  <option>Grayton Beach</option>
+                  <option>WaterColor</option>
+                  <option>Alys Beach</option>
+                  <option>Destin</option>
+                  <option>Panama City Beach</option>
+                </select>
+              </div>
+              <table class="data-table" aria-describedby="submissions-heading">
+                <thead>
+                  <tr>
+                    <th scope="col">Role</th>
+                    <th scope="col">Company</th>
+                    <th scope="col">Location</th>
+                    <th scope="col">Schedule</th>
+                  </tr>
+                </thead>
+                <tbody id="jobs-body"></tbody>
+              </table>
+              <div class="cta-group">
+                <button class="button button-outline" id="export-jobs" type="button">Export Jobs JSON</button>
+                <button class="button button-outline" id="clear-jobs" type="button">Clear Community Jobs</button>
+              </div>
+            </div>
+            <div>
+              <h3>Resumes Pool</h3>
+              <p class="form-footnote">Review and amplify standout service leaders before peak season hits.</p>
+              <table class="data-table" aria-label="Submitted resumes">
+                <thead>
+                  <tr>
+                    <th scope="col">Name</th>
+                    <th scope="col">Focus</th>
+                    <th scope="col">Home Base</th>
+                  </tr>
+                </thead>
+                <tbody id="resumes-body"></tbody>
+              </table>
+              <div class="cta-group">
+                <button class="button button-outline" id="export-resumes" type="button">Export Resumes JSON</button>
+                <button class="button button-outline" id="clear-resumes" type="button">Clear Community Resumes</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="container footer-bottom">
+      <p>&copy; <span id="admin-year"></span> Hire30A Admin Preview</p>
+      <a href="sitemap.xml">Sitemap</a>
+    </div>
+  </footer>
+
+  <script src="assets/js/admin.js" defer></script>
+</body>
+</html>

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,0 +1,605 @@
+:root {
+  --brand-sand: #f9f4eb;
+  --brand-seafoam: #7ed4d4;
+  --brand-emerald: #0096a1;
+  --brand-navy: #002b36;
+  --brand-coral: #ff7a59;
+  --brand-sun: #ffd166;
+  --text-primary: #103036;
+  --text-secondary: #3f5b60;
+  --shadow-soft: 0 20px 45px rgba(0, 43, 54, 0.15);
+  --radius-lg: 32px;
+  --radius-md: 20px;
+  --radius-sm: 12px;
+  --max-width: 1120px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Raleway", "Helvetica Neue", Arial, sans-serif;
+  color: var(--text-primary);
+  background: var(--brand-sand);
+  line-height: 1.6;
+  min-height: 100vh;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  color: var(--brand-emerald);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.container {
+  width: min(100%, var(--max-width));
+  margin: 0 auto;
+  padding: 0 1.5rem;
+}
+
+.top-nav {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: rgba(249, 244, 235, 0.92);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid rgba(0, 150, 161, 0.12);
+}
+
+.top-nav .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 1.5rem;
+}
+
+.nav-list {
+  list-style: none;
+  display: flex;
+  gap: 1.2rem;
+  padding: 0;
+  margin: 0;
+  font-weight: 600;
+}
+
+.nav-list a {
+  padding: 0.4rem 0.6rem;
+  border-radius: 999px;
+  transition: background 0.2s ease;
+}
+
+.nav-list a:hover,
+.nav-list a:focus {
+  background: rgba(0, 150, 161, 0.12);
+}
+
+.button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.75rem 1.6rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, var(--brand-emerald), var(--brand-seafoam));
+  color: #fff;
+  font-family: "Montserrat", sans-serif;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.button:hover,
+.button:focus {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-soft);
+}
+
+.button-outline {
+  background: transparent;
+  color: var(--brand-emerald);
+  border: 2px solid var(--brand-emerald);
+}
+
+.button-outline:hover,
+.button-outline:focus {
+  background: rgba(126, 212, 212, 0.2);
+  color: var(--brand-navy);
+}
+
+.hero {
+  padding: 6rem 0 5rem;
+  background: radial-gradient(circle at 15% 20%, rgba(255, 209, 102, 0.25) 0, transparent 45%),
+    radial-gradient(circle at 85% 10%, rgba(255, 122, 89, 0.25) 0, transparent 55%),
+    linear-gradient(180deg, rgba(0, 150, 161, 0.08), transparent 60%);
+}
+
+.hero-grid {
+  display: grid;
+  gap: 3rem;
+  align-items: center;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.eyebrow {
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  font-family: "Montserrat", sans-serif;
+  font-weight: 600;
+  color: var(--brand-emerald);
+  margin-bottom: 1rem;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  font-family: "Montserrat", sans-serif;
+  color: var(--brand-navy);
+  margin-top: 0;
+}
+
+.lead {
+  font-size: 1.1rem;
+  color: var(--text-secondary);
+}
+
+.cta-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin: 2rem 0 2.5rem;
+}
+
+.hero-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 1.5rem;
+  margin: 0;
+}
+
+.hero-stats dt {
+  font-size: 2.25rem;
+  font-weight: 700;
+  color: var(--brand-emerald);
+}
+
+.hero-card {
+  padding: 2.4rem;
+  border-radius: var(--radius-lg);
+  background: #fff;
+  box-shadow: var(--shadow-soft);
+}
+
+.hero-card h2 {
+  margin-bottom: 1rem;
+}
+
+.highlight-list {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0;
+  display: grid;
+  gap: 1rem;
+  color: var(--text-secondary);
+}
+
+.highlight-list li::before {
+  content: "";
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  margin-right: 0.6rem;
+  border-radius: 50%;
+  background: var(--brand-coral);
+}
+
+.hero-footer {
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+  margin-top: 1.5rem;
+}
+
+.section {
+  padding: 5rem 0;
+}
+
+.section-alt {
+  background: #fff;
+}
+
+.section-header {
+  text-align: center;
+  max-width: 720px;
+  margin: 0 auto 3rem;
+}
+
+.section-header p {
+  color: var(--text-secondary);
+}
+
+.feature-grid {
+  display: grid;
+  gap: 1.8rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.feature-card {
+  padding: 2rem;
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(0, 150, 161, 0.12);
+  backdrop-filter: blur(4px);
+}
+
+.filter-panel {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(210px, 1fr));
+  margin-bottom: 1.5rem;
+}
+
+.field {
+  display: grid;
+  gap: 0.4rem;
+}
+
+label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+input,
+select,
+textarea {
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-sm);
+  border: 1px solid rgba(16, 48, 54, 0.15);
+  font-family: inherit;
+  background: #fff;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  border-color: var(--brand-emerald);
+  box-shadow: 0 0 0 3px rgba(126, 212, 212, 0.35);
+  outline: none;
+}
+
+.job-summary {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-bottom: 1rem;
+  color: var(--text-secondary);
+}
+
+.job-summary strong {
+  font-size: 1.4rem;
+  color: var(--brand-navy);
+}
+
+.job-list {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.job-card {
+  display: grid;
+  gap: 1.2rem;
+  padding: 2rem;
+  border-radius: var(--radius-md);
+  background: #fff;
+  border: 1px solid rgba(0, 150, 161, 0.1);
+  box-shadow: 0 10px 24px rgba(16, 48, 54, 0.08);
+}
+
+.job-card header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: center;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(0, 150, 161, 0.14);
+  color: var(--brand-navy);
+  font-weight: 600;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.job-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.job-actions {
+  display: flex;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+}
+
+.form-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.card {
+  background: #fff;
+  border-radius: var(--radius-md);
+  padding: 2.2rem;
+  box-shadow: var(--shadow-soft);
+  border: 1px solid rgba(0, 150, 161, 0.08);
+}
+
+.form-footnote {
+  font-size: 0.85rem;
+  color: var(--text-secondary);
+}
+
+.resume-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.resume-card {
+  padding: 1.8rem;
+  border-radius: var(--radius-md);
+  background: linear-gradient(135deg, rgba(0, 150, 161, 0.12), rgba(126, 212, 212, 0.16));
+  border: 1px solid rgba(0, 150, 161, 0.2);
+}
+
+.resume-card h3 {
+  margin-bottom: 0.4rem;
+}
+
+.resume-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 1rem 0 0;
+  display: grid;
+  gap: 0.5rem;
+  color: var(--text-secondary);
+}
+
+.map-grid {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: center;
+}
+
+.map-panel {
+  background: #fff;
+  border-radius: var(--radius-md);
+  padding: 2rem;
+  box-shadow: 0 15px 30px rgba(0, 43, 54, 0.12);
+}
+
+.map-visual {
+  background: linear-gradient(135deg, rgba(255, 209, 102, 0.35), rgba(126, 212, 212, 0.25));
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  padding: 1.5rem;
+}
+
+.timeline {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.timeline li {
+  background: #fff;
+  border-radius: var(--radius-md);
+  padding: 1.8rem;
+  border: 1px solid rgba(0, 150, 161, 0.12);
+  position: relative;
+  box-shadow: 0 15px 30px rgba(16, 48, 54, 0.08);
+}
+
+.timeline li::before {
+  content: "";
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--brand-coral);
+  position: absolute;
+  left: 1.2rem;
+  top: 1.5rem;
+}
+
+.timeline h3 {
+  margin-left: 1.8rem;
+}
+
+.timeline p {
+  margin-left: 1.8rem;
+  color: var(--text-secondary);
+}
+
+.cta-card {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  align-items: center;
+  background: linear-gradient(135deg, rgba(0, 150, 161, 0.85), rgba(0, 43, 54, 0.9));
+  color: #fff;
+  border-radius: var(--radius-lg);
+  padding: 3rem;
+  box-shadow: var(--shadow-soft);
+}
+
+.cta-card p {
+  margin-bottom: 0;
+}
+
+.cta-card input {
+  background: rgba(255, 255, 255, 0.12);
+  border-color: rgba(255, 255, 255, 0.35);
+  color: #fff;
+}
+
+.cta-card input::placeholder {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.site-footer {
+  background: #001d24;
+  color: rgba(255, 255, 255, 0.86);
+  padding: 4rem 0 2rem;
+}
+
+.footer-grid {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.site-footer h3 {
+  color: #fff;
+  margin-bottom: 1rem;
+}
+
+.footer-tagline {
+  color: rgba(255, 255, 255, 0.78);
+}
+
+.footer-small {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.footer-bottom {
+  margin-top: 3rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  font-size: 0.9rem;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 720px) {
+  .top-nav .container {
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .nav-list {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .hero {
+    padding-top: 5rem;
+  }
+
+  .hero-card {
+    padding: 2rem;
+  }
+
+  .timeline li::before {
+    left: 0.8rem;
+  }
+
+  .timeline h3,
+  .timeline p {
+    margin-left: 1.4rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
+.empty-state {
+  background: rgba(255, 255, 255, 0.7);
+  border-radius: var(--radius-md);
+  padding: 1.8rem;
+  text-align: center;
+  color: var(--text-secondary);
+}
+
+.success,
+.newsletter-success {
+  margin-top: 1rem;
+  color: var(--brand-emerald);
+  font-weight: 600;
+}
+
+.newsletter-success {
+  text-align: center;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+  font-size: 0.95rem;
+}
+
+.data-table th,
+.data-table td {
+  text-align: left;
+  padding: 0.75rem 0.5rem;
+  border-bottom: 1px solid rgba(0, 43, 54, 0.1);
+}
+
+.data-table th {
+  font-family: "Montserrat", sans-serif;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: var(--brand-navy);
+}
+
+.data-table tbody tr:hover {
+  background: rgba(126, 212, 212, 0.12);
+}

--- a/assets/images/emerald-coast-map.svg
+++ b/assets/images/emerald-coast-map.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 260" role="img" aria-labelledby="mapTitle mapDesc">
+  <title id="mapTitle">Stylized Emerald Coast Map</title>
+  <desc id="mapDesc">Abstract illustration of Florida's Emerald Coast highlighting Santa Rosa Beach, Destin, and Panama City Beach.</desc>
+  <defs>
+    <linearGradient id="ocean" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#7ed4d4" />
+      <stop offset="100%" stop-color="#0096a1" />
+    </linearGradient>
+  </defs>
+  <rect width="480" height="260" rx="28" fill="url(#ocean)" opacity="0.85" />
+  <path d="M30 150c90-62 180-72 300-44 60 14 96 20 120 14v60c-42 16-114 34-210 30-108-4-156-20-210-60z" fill="#f9f4eb" opacity="0.9" />
+  <g fill="#ff7a59">
+    <circle cx="170" cy="120" r="10" />
+    <circle cx="300" cy="110" r="10" />
+    <circle cx="380" cy="140" r="10" />
+  </g>
+  <g font-family="Montserrat, Arial, sans-serif" font-weight="600" font-size="18" fill="#002b36">
+    <text x="150" y="108">Santa Rosa Beach</text>
+    <text x="286" y="96">Destin</text>
+    <text x="350" y="132">Panama City Beach</text>
+  </g>
+</svg>

--- a/assets/images/favicon.svg
+++ b/assets/images/favicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <defs>
+    <linearGradient id="fg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0096a1" />
+      <stop offset="100%" stop-color="#7ed4d4" />
+    </linearGradient>
+  </defs>
+  <rect width="64" height="64" rx="16" fill="#002b36" />
+  <path d="M12 38c6-7 12-10 20-10s14 3 20 10H12z" fill="url(#fg)" />
+  <circle cx="32" cy="24" r="10" fill="#ffd166" />
+</svg>

--- a/assets/images/hire30a-logo.svg
+++ b/assets/images/hire30a-logo.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 80" role="img" aria-labelledby="title desc">
+  <title id="title">Hire30A logo</title>
+  <desc id="desc">Wordmark for Hire30A featuring gradient sun and wave motif.</desc>
+  <defs>
+    <linearGradient id="sunrise" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffd166" />
+      <stop offset="100%" stop-color="#ff7a59" />
+    </linearGradient>
+    <linearGradient id="wave" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#0096a1" />
+      <stop offset="100%" stop-color="#7ed4d4" />
+    </linearGradient>
+  </defs>
+  <g font-family="Montserrat, Arial, sans-serif" font-weight="700" font-size="44" fill="#002b36">
+    <text x="90" y="52">Hire</text>
+    <text x="194" y="52" fill="url(#wave)">30A</text>
+  </g>
+  <g transform="translate(20 16)">
+    <circle cx="24" cy="24" r="24" fill="url(#sunrise)" opacity="0.85" />
+    <path d="M0 36c8-8 16-12 24-12s16 4 24 12H0z" fill="url(#wave)" />
+  </g>
+</svg>

--- a/assets/images/hire30a-social.svg
+++ b/assets/images/hire30a-social.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" role="img" aria-labelledby="socialTitle socialDesc">
+  <title id="socialTitle">Hire30A Social Share Graphic</title>
+  <desc id="socialDesc">Promotional graphic for Hire30A highlighting hospitality careers across Santa Rosa Beach, Destin, and Panama City Beach.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#002b36" />
+      <stop offset="100%" stop-color="#0096a1" />
+    </linearGradient>
+    <linearGradient id="wave" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#7ed4d4" />
+      <stop offset="100%" stop-color="#0096a1" />
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)" />
+  <path d="M0 470c180-120 360-140 560-86 220 52 350 48 640-14v260H0z" fill="#f9f4eb" opacity="0.85" />
+  <g font-family="Montserrat, Arial, sans-serif" font-weight="700" fill="#f9f4eb">
+    <text x="120" y="220" font-size="120">Hire30A</text>
+    <text x="120" y="320" font-size="54" font-weight="600">Gulf Coast Hospitality Careers</text>
+  </g>
+  <g font-family="Raleway, Arial, sans-serif" font-weight="600" font-size="34" fill="#002b36">
+    <text x="120" y="420">Locals hiring locals across Santa Rosa Beach, Destin, and Panama City Beach</text>
+  </g>
+  <g fill="#ff7a59">
+    <circle cx="880" cy="240" r="90" opacity="0.85" />
+    <circle cx="1040" cy="190" r="60" opacity="0.45" />
+  </g>
+  <path d="M720 420c60-60 120-80 200-80s140 20 200 80H720z" fill="url(#wave)" opacity="0.75" />
+</svg>

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,0 +1,394 @@
+const defaultSettings = {
+  primaryColor: "#0096a1",
+  secondaryColor: "#7ed4d4",
+  accentColor: "#ff7a59",
+  heroHeading: "Hire30A unites Gulf Coast hospitality talent with thriving coastal businesses.",
+  heroLead:
+    "From the sugar-white shores of Santa Rosa Beach to Destin and Panama City Beach, we make it effortless to post jobs, showcase resumes, and fill shifts with trusted locals."
+};
+
+const jobSeed = [
+  {
+    id: "job-1",
+    title: "Sunrise Barista",
+    company: "Gulf Grind Coffee Co.",
+    location: "Seaside",
+    category: "Food & Beverage",
+    schedule: "Part-time",
+    description:
+      "Craft signature coastal lattes, keep the espresso bar sparkling, and share local tips with the sunrise crowd.",
+    perks: ["Tip share", "Beachfront parking", "Shift beverages"],
+    posted: "Posted 2 hours ago",
+    applyUrl: "mailto:hello@gulfgrind30a.com"
+  },
+  {
+    id: "job-2",
+    title: "Boutique Resort Concierge",
+    company: "WaterColor Inn",
+    location: "WaterColor",
+    category: "Hotel & Resort",
+    schedule: "Full-time",
+    description:
+      "Deliver award-winning guest experiences, coordinate custom itineraries, and liaise with local partners.",
+    perks: ["401k match", "Wellness stipend", "Complimentary bike"],
+    posted: "Posted today",
+    applyUrl: "https://watercolorinn.com/careers"
+  },
+  {
+    id: "job-3",
+    title: "Banquet Captain",
+    company: "Grayton Gathering House",
+    location: "Grayton Beach",
+    category: "Events & Weddings",
+    schedule: "Seasonal",
+    description:
+      "Lead set-up crews, orchestrate plated dinners, and collaborate with Gulf-side chefs for destination weddings.",
+    perks: ["Event bonuses", "Team meals", "Cross-training"],
+    posted: "Posted yesterday",
+    applyUrl: "mailto:banquets@graytongathering.com"
+  },
+  {
+    id: "job-4",
+    title: "Vacation Rental Guest Services Guide",
+    company: "Emerald Escapes",
+    location: "Miramar Beach",
+    category: "Vacation Rentals",
+    schedule: "Full-time",
+    description:
+      "Coordinate arrivals, deliver concierge-level communications, and champion five-star guest reviews.",
+    perks: ["Commission", "Hybrid work", "Education stipend"],
+    posted: "Posted 3 days ago",
+    applyUrl: "https://emeraldescapesfl.com/hiring"
+  },
+  {
+    id: "job-5",
+    title: "Lead Mixologist",
+    company: "Pier Park Rooftop Lounge",
+    location: "Panama City Beach",
+    category: "Food & Beverage",
+    schedule: "Full-time",
+    description:
+      "Design seasonal cocktail menus, mentor bar teams, and host weekly mixology workshops for resort guests.",
+    perks: ["Creative freedom", "Signing bonus", "Housing assistance"],
+    posted: "Posted 5 days ago",
+    applyUrl: "mailto:careers@pierparkrooftop.com"
+  },
+  {
+    id: "job-6",
+    title: "Waterfront Event Producer",
+    company: "HarborLights Destin",
+    location: "Destin",
+    category: "Events & Weddings",
+    schedule: "Contract",
+    description:
+      "Produce signature experiences aboard luxury charters, manage vendor relations, and deliver flawless execution.",
+    perks: ["Profit share", "Sunset sails", "Vendor discounts"],
+    posted: "Posted 1 week ago",
+    applyUrl: "https://harborlightsdestin.com/events"
+  }
+];
+
+const resumeSeed = [
+  {
+    id: "resume-1",
+    name: "Maya Thompson",
+    role: "Beachfront Restaurant General Manager",
+    location: "Seaside, FL",
+    highlights: [
+      "Scaled seasonal teams from 15 to 60 without losing service quality",
+      "Beverage program generated 18% year-over-year growth",
+      "ServSafe, Cicerone Certified, fluent in Spanish"
+    ],
+    contact: "mailto:maya.thompson@hire30a.com"
+  },
+  {
+    id: "resume-2",
+    name: "Connor Jenkins",
+    role: "Luxury Resort Concierge",
+    location: "Miramar Beach, FL",
+    highlights: [
+      "Maintains 4.9 guest satisfaction score across 300+ stays",
+      "Local expert on fishing charters and private chefs",
+      "CPR certified, knowledge of ADA travel requirements"
+    ],
+    contact: "mailto:connor.jenkins@hire30a.com"
+  },
+  {
+    id: "resume-3",
+    name: "Sage Rivera",
+    role: "Event Stylist & Planner",
+    location: "Alys Beach, FL",
+    highlights: [
+      "Designed 40+ destination weddings across 30A and Destin",
+      "Partnerships with premier florists and entertainment",
+      "Experience with 400-guest corporate retreats"
+    ],
+    contact: "mailto:sage.rivera@hire30a.com"
+  }
+];
+
+const elements = {
+  themeForm: document.getElementById("theme-form"),
+  contentForm: document.getElementById("content-form"),
+  primaryColor: document.getElementById("primary-color"),
+  secondaryColor: document.getElementById("secondary-color"),
+  accentColor: document.getElementById("accent-color"),
+  heroHeadingInput: document.getElementById("hero-heading-input"),
+  heroLeadInput: document.getElementById("hero-lead-input"),
+  resetTheme: document.getElementById("reset-theme"),
+  resetContent: document.getElementById("reset-content"),
+  jobAreaFilter: document.getElementById("job-area-filter"),
+  jobsBody: document.getElementById("jobs-body"),
+  resumesBody: document.getElementById("resumes-body"),
+  exportJobs: document.getElementById("export-jobs"),
+  exportResumes: document.getElementById("export-resumes"),
+  clearJobs: document.getElementById("clear-jobs"),
+  clearResumes: document.getElementById("clear-resumes"),
+  year: document.getElementById("admin-year")
+};
+
+function getStoredObject(key, fallback) {
+  try {
+    const stored = localStorage.getItem(key);
+    if (!stored) return fallback;
+    const parsed = JSON.parse(stored);
+    return parsed && typeof parsed === "object" ? { ...fallback, ...parsed } : fallback;
+  } catch (error) {
+    console.warn(`Unable to load ${key} from storage`, error);
+    return fallback;
+  }
+}
+
+function getStoredArray(key, fallback) {
+  try {
+    const stored = localStorage.getItem(key);
+    if (!stored) return fallback;
+    const parsed = JSON.parse(stored);
+    return Array.isArray(parsed) ? parsed : fallback;
+  } catch (error) {
+    console.warn(`Unable to load ${key} from storage`, error);
+    return fallback;
+  }
+}
+
+let defaultJobs = [];
+let defaultResumes = [];
+
+let settings = getStoredObject("hire30a-settings", defaultSettings);
+let jobs = [];
+let resumes = [];
+
+function primeDefaultStorage() {
+  try {
+    if (!localStorage.getItem("hire30a-default-jobs")) {
+      localStorage.setItem("hire30a-default-jobs", JSON.stringify(jobSeed));
+    }
+    if (!localStorage.getItem("hire30a-default-resumes")) {
+      localStorage.setItem("hire30a-default-resumes", JSON.stringify(resumeSeed));
+    }
+  } catch (error) {
+    console.warn("Unable to prime admin defaults", error);
+  }
+}
+
+function applyPreviewStyles() {
+  const root = document.documentElement;
+  if (!root) return;
+  root.style.setProperty("--brand-emerald", settings.primaryColor);
+  root.style.setProperty("--brand-seafoam", settings.secondaryColor);
+  root.style.setProperty("--brand-coral", settings.accentColor);
+}
+
+function populateForms() {
+  if (elements.primaryColor) {
+    elements.primaryColor.value = settings.primaryColor;
+  }
+  if (elements.secondaryColor) {
+    elements.secondaryColor.value = settings.secondaryColor;
+  }
+  if (elements.accentColor) {
+    elements.accentColor.value = settings.accentColor;
+  }
+  if (elements.heroHeadingInput) {
+    elements.heroHeadingInput.value = settings.heroHeading;
+  }
+  if (elements.heroLeadInput) {
+    elements.heroLeadInput.value = settings.heroLead;
+  }
+  if (elements.year) {
+    elements.year.textContent = new Date().getFullYear();
+  }
+}
+
+function renderJobs(filterLocation = "") {
+  if (!elements.jobsBody) return;
+  elements.jobsBody.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  jobs
+    .filter((job) => (filterLocation ? job.location === filterLocation : true))
+    .forEach((job) => {
+      const row = document.createElement("tr");
+      row.innerHTML = `
+        <td>${job.title}</td>
+        <td>${job.company}</td>
+        <td>${job.location}</td>
+        <td>${job.schedule}</td>
+      `;
+      fragment.appendChild(row);
+    });
+  elements.jobsBody.appendChild(fragment);
+}
+
+function renderResumes() {
+  if (!elements.resumesBody) return;
+  elements.resumesBody.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+  resumes.forEach((profile) => {
+    const row = document.createElement("tr");
+    row.innerHTML = `
+      <td>${profile.name}</td>
+      <td>${profile.role}</td>
+      <td>${profile.location}</td>
+    `;
+    fragment.appendChild(row);
+  });
+  elements.resumesBody.appendChild(fragment);
+}
+
+function downloadJSON(filename, data) {
+  const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+function attachEvents() {
+  if (elements.themeForm) {
+    elements.themeForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+      elements.themeForm.querySelectorAll(".success").forEach((node) => node.remove());
+      settings = {
+        ...settings,
+        primaryColor: elements.primaryColor.value,
+        secondaryColor: elements.secondaryColor.value,
+        accentColor: elements.accentColor.value
+      };
+      localStorage.setItem("hire30a-settings", JSON.stringify(settings));
+      applyPreviewStyles();
+      elements.themeForm.insertAdjacentHTML(
+        "beforeend",
+        '<p class="form-footnote success">Brand palette saved. Refresh the public site to preview live.</p>'
+      );
+    });
+  }
+
+  if (elements.resetTheme) {
+    elements.resetTheme.addEventListener("click", () => {
+      settings = { ...defaultSettings };
+      localStorage.setItem("hire30a-settings", JSON.stringify(settings));
+      populateForms();
+      applyPreviewStyles();
+    });
+  }
+
+  if (elements.contentForm) {
+    elements.contentForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+      elements.contentForm.querySelectorAll(".success").forEach((node) => node.remove());
+      settings = {
+        ...settings,
+        heroHeading: elements.heroHeadingInput.value,
+        heroLead: elements.heroLeadInput.value
+      };
+      localStorage.setItem("hire30a-settings", JSON.stringify(settings));
+      elements.contentForm.insertAdjacentHTML(
+        "beforeend",
+        '<p class="form-footnote success">Messaging updated. Check the homepage to confirm.</p>'
+      );
+    });
+  }
+
+  if (elements.resetContent) {
+    elements.resetContent.addEventListener("click", () => {
+      settings = { ...settings, heroHeading: defaultSettings.heroHeading, heroLead: defaultSettings.heroLead };
+      localStorage.setItem("hire30a-settings", JSON.stringify(settings));
+      populateForms();
+    });
+  }
+
+  if (elements.jobAreaFilter) {
+    elements.jobAreaFilter.addEventListener("change", (event) => {
+      renderJobs(event.target.value);
+    });
+  }
+
+  if (elements.exportJobs) {
+    elements.exportJobs.addEventListener("click", () => {
+      downloadJSON("hire30a-jobs.json", jobs);
+    });
+  }
+
+  if (elements.exportResumes) {
+    elements.exportResumes.addEventListener("click", () => {
+      downloadJSON("hire30a-resumes.json", resumes);
+    });
+  }
+
+  if (elements.clearJobs) {
+    elements.clearJobs.addEventListener("click", () => {
+      if (confirm("Clear all community job submissions?")) {
+        jobs = defaultJobs.slice();
+        localStorage.setItem("hire30a-jobs", JSON.stringify(jobs));
+        renderJobs(elements.jobAreaFilter.value);
+      }
+    });
+  }
+
+  if (elements.clearResumes) {
+    elements.clearResumes.addEventListener("click", () => {
+      if (confirm("Clear all community resume submissions?")) {
+        resumes = defaultResumes.slice();
+        localStorage.setItem("hire30a-resumes", JSON.stringify(resumes));
+        renderResumes();
+      }
+    });
+  }
+
+  window.addEventListener("storage", (event) => {
+    if (event.key === "hire30a-jobs") {
+      jobs = getStoredArray("hire30a-jobs", defaultJobs);
+      renderJobs(elements.jobAreaFilter.value);
+    }
+    if (event.key === "hire30a-resumes") {
+      resumes = getStoredArray("hire30a-resumes", defaultResumes);
+      renderResumes();
+    }
+    if (event.key === "hire30a-settings") {
+      settings = getStoredObject("hire30a-settings", defaultSettings);
+      populateForms();
+      applyPreviewStyles();
+    }
+  });
+}
+
+function init() {
+  primeDefaultStorage();
+  defaultJobs = getStoredArray("hire30a-default-jobs", jobSeed);
+  defaultResumes = getStoredArray("hire30a-default-resumes", resumeSeed);
+  jobs = getStoredArray("hire30a-jobs", defaultJobs);
+  resumes = getStoredArray("hire30a-resumes", defaultResumes);
+  applyPreviewStyles();
+  populateForms();
+  renderJobs(elements.jobAreaFilter ? elements.jobAreaFilter.value : "");
+  renderResumes();
+  attachEvents();
+}
+
+if (document.readyState === "loading") {
+  document.addEventListener("DOMContentLoaded", init);
+} else {
+  init();
+}

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -1,0 +1,467 @@
+const defaultJobs = [
+  {
+    id: "job-1",
+    title: "Sunrise Barista",
+    company: "Gulf Grind Coffee Co.",
+    location: "Seaside",
+    category: "Food & Beverage",
+    schedule: "Part-time",
+    description:
+      "Craft signature coastal lattes, keep the espresso bar sparkling, and share local tips with the sunrise crowd.",
+    perks: ["Tip share", "Beachfront parking", "Shift beverages"],
+    posted: "Posted 2 hours ago",
+    applyUrl: "mailto:hello@gulfgrind30a.com"
+  },
+  {
+    id: "job-2",
+    title: "Boutique Resort Concierge",
+    company: "WaterColor Inn",
+    location: "WaterColor",
+    category: "Hotel & Resort",
+    schedule: "Full-time",
+    description:
+      "Deliver award-winning guest experiences, coordinate custom itineraries, and liaise with local partners.",
+    perks: ["401k match", "Wellness stipend", "Complimentary bike"],
+    posted: "Posted today",
+    applyUrl: "https://watercolorinn.com/careers"
+  },
+  {
+    id: "job-3",
+    title: "Banquet Captain",
+    company: "Grayton Gathering House",
+    location: "Grayton Beach",
+    category: "Events & Weddings",
+    schedule: "Seasonal",
+    description:
+      "Lead set-up crews, orchestrate plated dinners, and collaborate with Gulf-side chefs for destination weddings.",
+    perks: ["Event bonuses", "Team meals", "Cross-training"],
+    posted: "Posted yesterday",
+    applyUrl: "mailto:banquets@graytongathering.com"
+  },
+  {
+    id: "job-4",
+    title: "Vacation Rental Guest Services Guide",
+    company: "Emerald Escapes",
+    location: "Miramar Beach",
+    category: "Vacation Rentals",
+    schedule: "Full-time",
+    description:
+      "Coordinate arrivals, deliver concierge-level communications, and champion five-star guest reviews.",
+    perks: ["Commission", "Hybrid work", "Education stipend"],
+    posted: "Posted 3 days ago",
+    applyUrl: "https://emeraldescapesfl.com/hiring"
+  },
+  {
+    id: "job-5",
+    title: "Lead Mixologist",
+    company: "Pier Park Rooftop Lounge",
+    location: "Panama City Beach",
+    category: "Food & Beverage",
+    schedule: "Full-time",
+    description:
+      "Design seasonal cocktail menus, mentor bar teams, and host weekly mixology workshops for resort guests.",
+    perks: ["Creative freedom", "Signing bonus", "Housing assistance"],
+    posted: "Posted 5 days ago",
+    applyUrl: "mailto:careers@pierparkrooftop.com"
+  },
+  {
+    id: "job-6",
+    title: "Waterfront Event Producer",
+    company: "HarborLights Destin",
+    location: "Destin",
+    category: "Events & Weddings",
+    schedule: "Contract",
+    description:
+      "Produce signature experiences aboard luxury charters, manage vendor relations, and deliver flawless execution.",
+    perks: ["Profit share", "Sunset sails", "Vendor discounts"],
+    posted: "Posted 1 week ago",
+    applyUrl: "https://harborlightsdestin.com/events"
+  }
+];
+
+const defaultResumes = [
+  {
+    id: "resume-1",
+    name: "Maya Thompson",
+    role: "Beachfront Restaurant General Manager",
+    location: "Seaside, FL",
+    highlights: [
+      "Scaled seasonal teams from 15 to 60 without losing service quality",
+      "Beverage program generated 18% year-over-year growth",
+      "ServSafe, Cicerone Certified, fluent in Spanish"
+    ],
+    contact: "mailto:maya.thompson@hire30a.com"
+  },
+  {
+    id: "resume-2",
+    name: "Connor Jenkins",
+    role: "Luxury Resort Concierge",
+    location: "Miramar Beach, FL",
+    highlights: [
+      "Maintains 4.9 guest satisfaction score across 300+ stays",
+      "Local expert on fishing charters and private chefs",
+      "CPR certified, knowledge of ADA travel requirements"
+    ],
+    contact: "mailto:connor.jenkins@hire30a.com"
+  },
+  {
+    id: "resume-3",
+    name: "Sage Rivera",
+    role: "Event Stylist & Planner",
+    location: "Alys Beach, FL",
+    highlights: [
+      "Designed 40+ destination weddings across 30A and Destin",
+      "Partnerships with premier florists and entertainment",
+      "Experience with 400-guest corporate retreats"
+    ],
+    contact: "mailto:sage.rivera@hire30a.com"
+  }
+];
+
+const updates = [
+  "New: Pier Park Rooftop Lounge hiring Lead Mixologist in Panama City Beach",
+  "Wave Watch: WaterColor Inn opens 6 concierge roles for summer",
+  "Community spotlight: Grayton Gathering House seeks banquet talent",
+  "Talent drop: 8 seasoned bartenders added resumes this week",
+  "Destin charter partners launching seasonal hiring fair May 12"
+];
+
+const defaultSettings = {
+  primaryColor: "#0096a1",
+  secondaryColor: "#7ed4d4",
+  accentColor: "#ff7a59",
+  heroHeading: "Hire30A unites Gulf Coast hospitality talent with thriving coastal businesses.",
+  heroLead:
+    "From the sugar-white shores of Santa Rosa Beach to Destin and Panama City Beach, we make it effortless to post jobs, showcase resumes, and fill shifts with trusted locals."
+};
+
+const selectors = {
+  list: document.getElementById("job-list"),
+  count: document.getElementById("job-count"),
+  highlight: document.getElementById("job-highlight"),
+  heroUpdates: document.getElementById("hero-updates"),
+  resumeList: document.getElementById("resume-list"),
+  heroHeading: document.getElementById("hero-heading"),
+  heroLead: document.getElementById("hero-lead"),
+  year: document.getElementById("year"),
+  newsletter: document.getElementById("newsletter-form")
+};
+
+const filterForm = document.getElementById("job-filter");
+const jobForm = document.getElementById("job-form");
+const resumeForm = document.getElementById("resume-form");
+
+function getStoredData(key, fallback) {
+  try {
+    const stored = localStorage.getItem(key);
+    if (!stored) return fallback;
+    const parsed = JSON.parse(stored);
+    return Array.isArray(parsed) ? parsed : fallback;
+  } catch (error) {
+    console.warn(`Unable to load ${key} from storage`, error);
+    return fallback;
+  }
+}
+
+function storeData(key, value) {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    console.warn(`Unable to persist ${key} in storage`, error);
+  }
+}
+
+function getStoredObject(key, fallback) {
+  try {
+    const stored = localStorage.getItem(key);
+    if (!stored) return fallback;
+    const parsed = JSON.parse(stored);
+    return parsed && typeof parsed === "object" ? { ...fallback, ...parsed } : fallback;
+  } catch (error) {
+    console.warn(`Unable to load ${key} from storage`, error);
+    return fallback;
+  }
+}
+
+let jobs = getStoredData("hire30a-jobs", defaultJobs);
+let resumes = getStoredData("hire30a-resumes", defaultResumes);
+let brandSettings = getStoredObject("hire30a-settings", defaultSettings);
+
+function primeDefaultStorage() {
+  try {
+    if (!localStorage.getItem("hire30a-default-jobs")) {
+      localStorage.setItem("hire30a-default-jobs", JSON.stringify(defaultJobs));
+    }
+    if (!localStorage.getItem("hire30a-default-resumes")) {
+      localStorage.setItem("hire30a-default-resumes", JSON.stringify(defaultResumes));
+    }
+  } catch (error) {
+    console.warn("Unable to prime default storage", error);
+  }
+}
+
+function applyBrandSettings(settings) {
+  const root = document.documentElement;
+  if (root) {
+    root.style.setProperty("--brand-emerald", settings.primaryColor);
+    root.style.setProperty("--brand-seafoam", settings.secondaryColor);
+    root.style.setProperty("--brand-coral", settings.accentColor);
+  }
+
+  if (selectors.heroHeading) {
+    selectors.heroHeading.textContent = settings.heroHeading;
+  }
+
+  if (selectors.heroLead) {
+    selectors.heroLead.textContent = settings.heroLead;
+  }
+}
+
+function renderJobs(list) {
+  if (!selectors.list) return;
+  selectors.list.innerHTML = "";
+
+  if (!list.length) {
+    selectors.list.innerHTML = '<p class="empty-state">No jobs match your filters yet. Try another neighborhood or check back soon!</p>';
+  }
+
+  const fragment = document.createDocumentFragment();
+
+  list.forEach((job) => {
+    const card = document.createElement("article");
+    card.className = "job-card";
+    const perks = Array.isArray(job.perks) && job.perks.length
+      ? job.perks
+      : ["Featured on Hire30A", "Shared with local partners", "Amplified via socials"];
+    const applyUrl = job.applyUrl || "mailto:hello@hire30a.com";
+    card.innerHTML = `
+      <header>
+        <div>
+          <h3>${job.title}</h3>
+          <p class="job-meta">
+            <span>${job.company}</span>
+            <span>&bull;</span>
+            <span>${job.location}</span>
+          </p>
+        </div>
+        <div class="job-actions">
+          <span class="badge">${job.schedule}</span>
+          <span class="badge">${job.category}</span>
+        </div>
+      </header>
+      <p>${job.description}</p>
+      <ul class="highlight-list">
+        ${perks.map((perk) => `<li>${perk}</li>`).join("")}
+      </ul>
+      <footer class="job-meta">
+        <span>${job.posted}</span>
+        <a class="button button-outline" href="${applyUrl}" target="_blank" rel="noopener">Apply / Inquire</a>
+      </footer>
+    `;
+    fragment.appendChild(card);
+  });
+
+  selectors.list.appendChild(fragment);
+  selectors.count.textContent = list.length;
+
+  if (list.length) {
+    const primaryArea = list[0].location;
+    selectors.highlight.textContent = `Now trending in ${primaryArea}: ${list[0].title} at ${list[0].company}.`;
+  } else {
+    selectors.highlight.textContent = "Refine your filters or submit a new role for instant visibility.";
+  }
+}
+
+function renderResumes(list) {
+  if (!selectors.resumeList) return;
+  selectors.resumeList.innerHTML = "";
+  const fragment = document.createDocumentFragment();
+
+  list.forEach((profile) => {
+    const card = document.createElement("article");
+    card.className = "resume-card";
+    const highlights = Array.isArray(profile.highlights) && profile.highlights.length
+      ? profile.highlights
+      : ["Hospitality pro ready to connect", "Reach out to learn more"];
+    const contact = profile.contact || "mailto:hello@hire30a.com";
+    card.innerHTML = `
+      <h3>${profile.name}</h3>
+      <p><strong>${profile.role}</strong></p>
+      <p>${profile.location}</p>
+      <ul>
+        ${highlights.map((item) => `<li>${item}</li>`).join("")}
+      </ul>
+      <p><a class="button button-outline" href="${contact}">Connect</a></p>
+    `;
+    fragment.appendChild(card);
+  });
+
+  selectors.resumeList.appendChild(fragment);
+}
+
+function applyFilters() {
+  const formData = new FormData(filterForm);
+  const search = formData.get("search").toLowerCase().trim();
+  const location = formData.get("location");
+  const category = formData.get("category");
+  const schedule = formData.get("schedule");
+
+  const filtered = jobs.filter((job) => {
+    const matchesSearch = search
+      ? [job.title, job.company, job.location, job.description]
+          .join(" ")
+          .toLowerCase()
+          .includes(search)
+      : true;
+    const matchesLocation = location ? job.location === location : true;
+    const matchesCategory = category ? job.category === category : true;
+    const matchesSchedule = schedule ? job.schedule === schedule : true;
+    return matchesSearch && matchesLocation && matchesCategory && matchesSchedule;
+  });
+
+  renderJobs(filtered);
+}
+
+function rotateUpdates() {
+  if (!selectors.heroUpdates) return;
+  selectors.heroUpdates.innerHTML = updates
+    .map((update) => `<li>${update}</li>`)
+    .join("");
+
+  let index = 0;
+  const items = selectors.heroUpdates.querySelectorAll("li");
+  items.forEach((item, idx) => {
+    item.setAttribute("role", "status");
+    if (idx !== 0) {
+      item.style.display = "none";
+    }
+  });
+
+  setInterval(() => {
+    if (!items.length) return;
+    items[index].style.display = "none";
+    index = (index + 1) % items.length;
+    items[index].style.display = "list-item";
+  }, 5000);
+}
+
+function attachFormHandlers() {
+  if (jobForm) {
+    jobForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+      const formData = new FormData(jobForm);
+      const newJob = {
+        id: `job-${Date.now()}`,
+        title: formData.get("jobTitle"),
+        company: formData.get("jobCompany"),
+        location: formData.get("jobLocation"),
+        category: formData.get("jobCategory"),
+        schedule: formData.get("jobSchedule"),
+        description: formData.get("jobDescription"),
+        perks: ["Locals-first visibility", "Featured in weekly newsletter", "Amplified via social"],
+        posted: "Just added via Hire30A",
+        applyUrl: `mailto:${formData.get("jobContact")}`
+      };
+
+      jobs = [newJob, ...jobs];
+      storeData("hire30a-jobs", jobs);
+      jobForm.reset();
+      applyFilters();
+      jobForm.querySelectorAll(".success").forEach((node) => node.remove());
+      jobForm.insertAdjacentHTML(
+        "beforeend",
+        '<p class="form-footnote success">Thanks! Your role is now live and queued for curation.</p>'
+      );
+    });
+  }
+
+  if (resumeForm) {
+    resumeForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+      const formData = new FormData(resumeForm);
+      const newProfile = {
+        id: `resume-${Date.now()}`,
+        name: formData.get("resumeName"),
+        role: formData.get("resumeRole"),
+        location: formData.get("resumeLocation"),
+        highlights: [
+          formData.get("resumeExperience"),
+          "Available for interviews",
+          `Contact: ${formData.get("resumeContact")}`
+        ],
+        contact: `mailto:${formData.get("resumeContact")}`
+      };
+
+      resumes = [newProfile, ...resumes];
+      storeData("hire30a-resumes", resumes);
+      resumeForm.reset();
+      renderResumes(resumes.slice(0, 6));
+      resumeForm.querySelectorAll(".success").forEach((node) => node.remove());
+      resumeForm.insertAdjacentHTML(
+        "beforeend",
+        '<p class="form-footnote success">Your coastal resume is now visible to Hire30A partners.</p>'
+      );
+    });
+  }
+
+  if (selectors.newsletter) {
+    selectors.newsletter.addEventListener("submit", (event) => {
+      event.preventDefault();
+      const input = selectors.newsletter.querySelector("input");
+      input.value = "";
+      selectors.newsletter.insertAdjacentHTML(
+        "afterend",
+        '<p class="newsletter-success">You\'re on the list! Watch for weekly 30A hiring highlights.</p>'
+      );
+    });
+  }
+}
+
+function cleanupDuplicateNotices() {
+  document.querySelectorAll(".success").forEach((message, index) => {
+    if (index > 0) message.remove();
+  });
+
+  document.querySelectorAll(".newsletter-success").forEach((message, index) => {
+    if (index > 0) message.remove();
+  });
+}
+
+function init() {
+  if (selectors.year) {
+    selectors.year.textContent = new Date().getFullYear();
+  }
+
+  primeDefaultStorage();
+  applyBrandSettings(brandSettings);
+  renderJobs(jobs);
+  renderResumes(resumes.slice(0, 6));
+  rotateUpdates();
+  attachFormHandlers();
+
+  if (filterForm) {
+    filterForm.addEventListener("input", () => {
+      cleanupDuplicateNotices();
+      applyFilters();
+    });
+  }
+
+  document.addEventListener("click", cleanupDuplicateNotices);
+
+  window.addEventListener("storage", (event) => {
+    if (event.key === "hire30a-settings") {
+      brandSettings = getStoredObject("hire30a-settings", defaultSettings);
+      applyBrandSettings(brandSettings);
+    }
+    if (event.key === "hire30a-jobs") {
+      jobs = getStoredData("hire30a-jobs", defaultJobs);
+      applyFilters();
+    }
+    if (event.key === "hire30a-resumes") {
+      resumes = getStoredData("hire30a-resumes", defaultResumes);
+      renderResumes(resumes.slice(0, 6));
+    }
+  });
+}
+
+window.addEventListener("DOMContentLoaded", init);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,411 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="x-ua-compatible" content="ie=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Hire30A | Gulf Coast Hospitality Jobs & Talent Community</title>
+  <meta name="description" content="Hire30A connects Santa Rosa Beach, Destin, and Panama City Beach hospitality businesses with local talent. Browse jobs, share resumes, and join the 30A hiring community." />
+  <meta name="keywords" content="Hire30A, Santa Rosa Beach jobs, 30A jobs, Destin hospitality careers, Panama City Beach hiring, local talent marketplace" />
+  <meta name="author" content="Hire30A" />
+  <link rel="canonical" href="https://hire30a.com/" />
+  <meta property="og:title" content="Hire30A | Gulf Coast Hospitality Jobs & Talent Community" />
+  <meta property="og:description" content="Discover hospitality careers and local talent along Florida's Scenic 30A corridor. Hire30A makes it easy to connect, hire, and thrive." />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://hire30a.com/" />
+  <meta property="og:image" content="https://hire30a.com/assets/images/hire30a-social.svg" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Hire30A | Gulf Coast Hospitality Jobs & Talent Community" />
+  <meta name="twitter:description" content="A community-built job marketplace for Santa Rosa Beach, Destin, and Panama City Beach hospitality pros." />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;600;700&family=Raleway:wght@300;400;600&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="assets/css/main.css" />
+  <link rel="icon" type="image/svg+xml" href="assets/images/favicon.svg" />
+  <link rel="manifest" href="site.webmanifest" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    "name": "Hire30A",
+    "url": "https://hire30a.com",
+    "logo": "https://hire30a.com/assets/images/hire30a-logo.svg",
+    "sameAs": [
+      "https://www.facebook.com/Hire30A",
+      "https://www.instagram.com/Hire30A",
+      "https://www.linkedin.com/company/hire30a"
+    ],
+    "description": "Hire30A is the go-to hospitality hiring community for Santa Rosa Beach, Destin, and Panama City Beach, Florida.",
+    "address": {
+      "@type": "PostalAddress",
+      "addressLocality": "Santa Rosa Beach",
+      "addressRegion": "FL",
+      "postalCode": "32459",
+      "addressCountry": "US"
+    },
+    "contactPoint": {
+      "@type": "ContactPoint",
+      "contactType": "customer service",
+      "email": "hello@hire30a.com"
+    }
+  }
+  </script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "JobPosting",
+    "title": "Front-of-House Manager",
+    "employmentType": "FULL_TIME",
+    "industry": "Hospitality",
+    "datePosted": "2024-05-01",
+    "validThrough": "2024-12-31",
+    "description": "Lead a guest-obsessed team at a beachfront restaurant in Santa Rosa Beach, FL with Hire30A.",
+    "jobLocation": {
+      "@type": "Place",
+      "address": {
+        "@type": "PostalAddress",
+        "addressLocality": "Santa Rosa Beach",
+        "addressRegion": "FL",
+        "postalCode": "32459",
+        "addressCountry": "US"
+      }
+    },
+    "hiringOrganization": {
+      "@type": "Organization",
+      "name": "Hire30A Partner Venue",
+      "sameAs": "https://hire30a.com"
+    }
+  }
+  </script>
+</head>
+<body>
+  <header class="top-nav" aria-label="Primary">
+    <div class="container">
+      <a class="brand" href="#top" aria-label="Hire30A home">
+        <img src="assets/images/hire30a-logo.svg" alt="Hire30A logo" width="140" height="36" loading="lazy" />
+      </a>
+      <nav>
+        <ul class="nav-list">
+          <li><a href="#about">About</a></li>
+          <li><a href="#jobs">Live Jobs</a></li>
+          <li><a href="#resumes">Resumes</a></li>
+          <li><a href="#map">30A Districts</a></li>
+          <li><a href="#newsletter">Stay Updated</a></li>
+          <li><a class="button button-outline" href="admin.html">Open Admin Portal</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main id="top">
+    <section class="hero" aria-labelledby="hero-heading">
+      <div class="container hero-grid">
+        <div>
+          <p class="eyebrow">Locals Hiring Locals</p>
+          <h1 id="hero-heading">Hire30A unites Gulf Coast hospitality talent with thriving coastal businesses.</h1>
+          <p id="hero-lead" class="lead">From the sugar-white shores of Santa Rosa Beach to Destin and Panama City Beach, we make it effortless to post jobs, showcase resumes, and fill shifts with trusted locals.</p>
+          <div class="cta-group">
+            <a class="button" href="#jobs">Browse Open Roles</a>
+            <a class="button button-outline" href="#post">Post a Job Free</a>
+          </div>
+          <dl class="hero-stats" aria-label="Community snapshot">
+            <div>
+              <dt>478</dt>
+              <dd>Hospitality Pros Ready to Work</dd>
+            </div>
+            <div>
+              <dt>126</dt>
+              <dd>Beachfront & Scenic 30A Employers</dd>
+            </div>
+            <div>
+              <dt>24 hrs</dt>
+              <dd>Average Time to Match Talent</dd>
+            </div>
+          </dl>
+        </div>
+        <div class="hero-card" role="complementary">
+          <h2>Real-time 30A Hiring Pulse</h2>
+          <ul class="highlight-list" id="hero-updates" aria-live="polite"></ul>
+          <p class="hero-footer">Updated hourly with community submissions and partner insights.</p>
+        </div>
+      </div>
+    </section>
+
+    <section id="about" class="section" aria-labelledby="about-heading">
+      <div class="container">
+        <div class="section-header">
+          <h2 id="about-heading">Why Hire30A?</h2>
+          <p>We are building the first hospitality-first hiring hub dedicated to Florida's Emerald Coast. Designed for mobile, optimized for search, and rooted in local vibes.</p>
+        </div>
+        <div class="feature-grid">
+          <article class="feature-card">
+            <h3>Community-Powered</h3>
+            <p>Locals trust Hire30A to share opportunities before they hit national job boards. Hyper-local signals mean the right fit every time.</p>
+          </article>
+          <article class="feature-card">
+            <h3>Hospitality Obsession</h3>
+            <p>Restaurants, boutique hotels, beach clubs, vacation rentals, event venues, wellness lounges &mdash; if it's part of the service scene, it belongs here.</p>
+          </article>
+          <article class="feature-card">
+            <h3>Coming Soon Platform</h3>
+            <p>Create accounts, manage brand colors, edit content, and oversee job flows through our admin portal. Today's preview, tomorrow's full-stack platform.</p>
+          </article>
+          <article class="feature-card">
+            <h3>SEO-Ready From Day One</h3>
+            <p>Structured data, local search targeting, and optimized copy keep Hire30A discoverable for locals and visitors hunting for talent or work.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section id="jobs" class="section section-alt" aria-labelledby="jobs-heading">
+      <div class="container">
+        <div class="section-header">
+          <h2 id="jobs-heading">Live Hospitality Opportunities</h2>
+          <p>Search and filter fresh postings across Santa Rosa Beach, Scenic 30A neighborhoods, Destin, and Panama City Beach.</p>
+        </div>
+        <form class="filter-panel" id="job-filter" aria-label="Job filter">
+          <div class="field">
+            <label for="search">Search keywords</label>
+            <input id="search" name="search" type="search" placeholder="e.g. bartender, concierge, Grayton Beach" />
+          </div>
+          <div class="field">
+            <label for="location">Location</label>
+            <select id="location" name="location">
+              <option value="">All of 30A</option>
+              <option>Santa Rosa Beach</option>
+              <option>Seaside</option>
+              <option>Grayton Beach</option>
+              <option>WaterColor</option>
+              <option>Alys Beach</option>
+              <option>Seagrove</option>
+              <option>Destin</option>
+              <option>Miramar Beach</option>
+              <option>Panama City Beach</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="category">Hospitality lane</label>
+            <select id="category" name="category">
+              <option value="">Any</option>
+              <option>Food &amp; Beverage</option>
+              <option>Hotel &amp; Resort</option>
+              <option>Vacation Rentals</option>
+              <option>Events &amp; Weddings</option>
+              <option>Wellness &amp; Spa</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="schedule">Schedule</label>
+            <select id="schedule" name="schedule">
+              <option value="">Any</option>
+              <option>Full-time</option>
+              <option>Part-time</option>
+              <option>Seasonal</option>
+              <option>Contract</option>
+            </select>
+          </div>
+        </form>
+        <div class="job-summary" aria-live="polite">
+          <p><strong id="job-count">0</strong> curated roles</p>
+          <p><span id="job-highlight"></span></p>
+        </div>
+        <div class="job-list" id="job-list" aria-live="polite"></div>
+      </div>
+    </section>
+
+    <section id="post" class="section" aria-labelledby="post-heading">
+      <div class="container">
+        <div class="section-header">
+          <h2 id="post-heading">Post a Job or Share Your Resume</h2>
+          <p>Submit opportunities or introduce yourself. We'll amplify every listing as we prepare the full Hire30A experience.</p>
+        </div>
+        <div class="form-grid">
+          <form id="job-form" class="card" aria-label="Post a job">
+            <h3>Submit a Job</h3>
+            <div class="field">
+              <label for="job-title">Job Title</label>
+              <input id="job-title" name="jobTitle" required />
+            </div>
+            <div class="field">
+              <label for="job-company">Company</label>
+              <input id="job-company" name="jobCompany" required />
+            </div>
+            <div class="field">
+              <label for="job-location">Location</label>
+              <input id="job-location" name="jobLocation" placeholder="e.g. Seaside, FL" required />
+            </div>
+            <div class="field">
+              <label for="job-type">Hospitality Lane</label>
+              <select id="job-type" name="jobCategory" required>
+                <option value="">Select one</option>
+                <option>Food &amp; Beverage</option>
+                <option>Hotel &amp; Resort</option>
+                <option>Vacation Rentals</option>
+                <option>Events &amp; Weddings</option>
+                <option>Wellness &amp; Spa</option>
+              </select>
+            </div>
+            <div class="field">
+              <label for="job-schedule">Schedule</label>
+              <select id="job-schedule" name="jobSchedule" required>
+                <option value="">Select schedule</option>
+                <option>Full-time</option>
+                <option>Part-time</option>
+                <option>Seasonal</option>
+                <option>Contract</option>
+              </select>
+            </div>
+            <div class="field">
+              <label for="job-description">Description</label>
+              <textarea id="job-description" name="jobDescription" rows="4" required></textarea>
+            </div>
+            <div class="field">
+              <label for="job-contact">Best Contact Email</label>
+              <input id="job-contact" type="email" name="jobContact" required />
+            </div>
+            <button class="button" type="submit">Add Listing</button>
+            <p class="form-footnote">All submissions appear instantly and are reviewable in the admin portal.</p>
+          </form>
+          <form id="resume-form" class="card" aria-label="Share a resume">
+            <h3>Submit Your Resume</h3>
+            <div class="field">
+              <label for="resume-name">Full Name</label>
+              <input id="resume-name" name="resumeName" required />
+            </div>
+            <div class="field">
+              <label for="resume-role">Desired Role</label>
+              <input id="resume-role" name="resumeRole" required />
+            </div>
+            <div class="field">
+              <label for="resume-location">Home Base</label>
+              <input id="resume-location" name="resumeLocation" placeholder="e.g. Rosemary Beach" required />
+            </div>
+            <div class="field">
+              <label for="resume-experience">Experience Highlights</label>
+              <textarea id="resume-experience" name="resumeExperience" rows="4" required></textarea>
+            </div>
+            <div class="field">
+              <label for="resume-contact">Contact Email</label>
+              <input id="resume-contact" type="email" name="resumeContact" required />
+            </div>
+            <button class="button button-outline" type="submit">Publish Resume</button>
+            <p class="form-footnote">We'll broadcast your skills to our partner network along the Emerald Coast.</p>
+          </form>
+        </div>
+      </div>
+    </section>
+
+    <section id="resumes" class="section section-alt" aria-labelledby="resume-heading">
+      <div class="container">
+        <div class="section-header">
+          <h2 id="resume-heading">Featured Locals Ready to Work</h2>
+          <p>Explore curated resumes from 30A service leaders, each available for seasonal surges and long-term partnerships.</p>
+        </div>
+        <div class="resume-grid" id="resume-list" aria-live="polite"></div>
+      </div>
+    </section>
+
+    <section id="map" class="section" aria-labelledby="map-heading">
+      <div class="container">
+        <div class="section-header">
+          <h2 id="map-heading">Every Corner of 30A &amp; Beyond</h2>
+          <p>Pinpoint opportunities by neighborhood with our micro-market filters covering Scenic Highway 30A, Destin Harbor, Pier Park, and more.</p>
+        </div>
+        <div class="map-grid">
+          <div class="map-panel">
+            <h3>Talent Hotspots</h3>
+            <ul class="highlight-list">
+              <li><strong>Blue Mountain Beach</strong> &ndash; wellness &amp; spa talent for boutique retreats.</li>
+              <li><strong>Seaside &amp; WaterColor</strong> &ndash; front-of-house stars who know every guest by name.</li>
+              <li><strong>Alys &amp; Rosemary Beach</strong> &ndash; fine dining and concierge specialists.</li>
+              <li><strong>Grayton Beach</strong> &ndash; live music venues, craft cocktail programs, culinary creativity.</li>
+              <li><strong>Destin &amp; Miramar</strong> &ndash; large-scale resort operations and charter experiences.</li>
+              <li><strong>Panama City Beach</strong> &ndash; entertainment venues and beachfront event staffing.</li>
+            </ul>
+          </div>
+          <figure class="map-visual" role="presentation" aria-hidden="true">
+            <img src="assets/images/emerald-coast-map.svg" alt="Stylized map of the Emerald Coast" loading="lazy" />
+          </figure>
+        </div>
+      </div>
+    </section>
+
+    <section class="section section-alt" aria-labelledby="milestones-heading">
+      <div class="container">
+        <div class="section-header">
+          <h2 id="milestones-heading">Roadmap to Launch</h2>
+          <p>Track the progress of our coming-soon platform as we build the all-in-one hiring toolkit for the Emerald Coast.</p>
+        </div>
+        <ol class="timeline">
+          <li>
+            <h3>Phase 1 &ndash; Public Beta</h3>
+            <p>Live job &amp; resume submissions, automated SEO optimization, and mobile-first experience for locals and visitors.</p>
+          </li>
+          <li>
+            <h3>Phase 2 &ndash; Account Creation</h3>
+            <p>Launch candidate and employer portals with saved searches, application tracking, and customizable brand pages.</p>
+          </li>
+          <li>
+            <h3>Phase 3 &ndash; Admin Intelligence</h3>
+            <p>Real-time analytics, color and content management, automated distribution to partner channels, and integrations with ATS/HRIS tools.</p>
+          </li>
+        </ol>
+      </div>
+    </section>
+
+    <section id="newsletter" class="section" aria-labelledby="newsletter-heading">
+      <div class="container">
+        <div class="cta-card">
+          <div>
+            <h2 id="newsletter-heading">Stay on the Wave</h2>
+            <p>Sign up to get platform launch updates, weekly hiring spotlights, and invites to 30A hospitality meetups.</p>
+          </div>
+          <form id="newsletter-form" aria-label="Newsletter signup">
+            <label class="sr-only" for="newsletter-email">Email address</label>
+            <input id="newsletter-email" type="email" placeholder="you@example.com" required />
+            <button class="button" type="submit">Notify Me</button>
+          </form>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer" aria-label="Footer">
+    <div class="container footer-grid">
+      <div>
+        <img src="assets/images/hire30a-logo.svg" alt="Hire30A" width="140" height="36" loading="lazy" />
+        <p class="footer-tagline">Hire30A is the hospitality hiring home for Santa Rosa Beach, Scenic 30A, Destin, and Panama City Beach.</p>
+      </div>
+      <div>
+        <h3>Explore</h3>
+        <ul>
+          <li><a href="#jobs">Job Board</a></li>
+          <li><a href="#resumes">Local Talent</a></li>
+          <li><a href="#map">District Insights</a></li>
+          <li><a href="admin.html">Admin Portal</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>Connect</h3>
+        <ul>
+          <li><a href="mailto:hello@hire30a.com">hello@hire30a.com</a></li>
+          <li><a href="tel:+18508659800">850-865-9800</a></li>
+          <li><a href="https://instagram.com/hire30a">Instagram</a></li>
+          <li><a href="https://linkedin.com/company/hire30a">LinkedIn</a></li>
+        </ul>
+      </div>
+      <div>
+        <h3>Local SEO Signals</h3>
+        <p class="footer-small">Serving Santa Rosa Beach, Grayton Beach, WaterColor, Seaside, Seagrove, Alys Beach, Rosemary Beach, Inlet Beach, Miramar Beach, Destin, and Panama City Beach, Florida.</p>
+      </div>
+    </div>
+    <div class="container footer-bottom">
+      <p>&copy; <span id="year"></span> Hire30A. All rights reserved.</p>
+      <a href="sitemap.xml">Sitemap</a>
+    </div>
+  </footer>
+
+  <script src="assets/js/main.js" defer></script>
+</body>
+</html>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://hire30a.com/sitemap.xml

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,0 +1,17 @@
+{
+  "name": "Hire30A",
+  "short_name": "Hire30A",
+  "description": "Locals hiring locals across Santa Rosa Beach, Destin, and Panama City Beach hospitality businesses.",
+  "start_url": "/",
+  "scope": "/",
+  "display": "standalone",
+  "background_color": "#f9f4eb",
+  "theme_color": "#0096a1",
+  "icons": [
+    {
+      "src": "assets/images/favicon.svg",
+      "sizes": "any",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://hire30a.com/</loc>
+    <priority>1.0</priority>
+    <changefreq>daily</changefreq>
+  </url>
+  <url>
+    <loc>https://hire30a.com/admin.html</loc>
+    <priority>0.6</priority>
+    <changefreq>weekly</changefreq>
+  </url>
+</urlset>


### PR DESCRIPTION
## Summary
- create an SEO-forward Hire30A landing page with hero storytelling, live job filters, resume highlights, and newsletter capture
- implement client-side logic for job/resume submissions, location-aware filtering, and brand customization persistence via localStorage
- add an admin portal preview, brand assets, manifest, and search engine helpers to round out the coming-soon experience

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c8b0f8d23083289c7fc98b13e29bbf